### PR TITLE
feat: add a new prometheus label parsing a jenkins node label

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ This exporter listen on port `9723` and the endpoint is `/metrics`
 ```
 # HELP jenkins_node_busy_status The busy status of a jenkins computer node 0:IDLE 1:BUSY
 # TYPE jenkins_node_busy_status gauge
-jenkins_node_busy_status{computerName="master"} 0
-jenkins_node_busy_status{computerName="node1"} 0
+jenkins_node_busy_status{computerName="master",role="worker"} 0
+jenkins_node_busy_status{computerName="node1",role="worker"} 0
 # HELP jenkins_node_exporter_failure The number of faillure to get/parse api data
 # TYPE jenkins_node_exporter_failure counter
 jenkins_node_exporter_failure 0
 # HELP jenkins_node_maintenance_status The maintenance status of a jenkins computer node 0:ONLINE 1:MAINTENANCE 2:OFFLINE
 # TYPE jenkins_node_maintenance_status gauge
-jenkins_node_maintenance_status{computerName="master"} 0
-jenkins_node_maintenance_status{computerName="node1"} 2
+jenkins_node_maintenance_status{computerName="master",role="worker"} 0
+jenkins_node_maintenance_status{computerName="node1",role="worker"} 2
 ```
 
 Available options:
@@ -28,6 +28,7 @@ Flags:
       --disable-authentication    disable authentication
       --fetch-interval duration   fetch-interval in seconds (default 30s)
   -h, --help                      help for jenkins-node-state-exporter
+  -r, --labelrole string          prefix of the label to parse a role associated with the node (default "role")
   -p, --password string           password of the jenkins user account (default "admin")
       --port int                  port to listen on (default 9827)
   -u, --username string           username of the jenkins user account (default "admin")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,10 @@ func init() {
 	if err := viper.BindPFlag("password", rootCmd.Flags().Lookup("password")); err != nil {
 		log.Fatal(err)
 	}
+	rootCmd.Flags().StringP("labelrole","r","role=","prefix of the label to parse a role associated with the node")
+	if err := viper.BindPFlag("labelrole", rootCmd.Flags().Lookup("labelrole")); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/exporter/computer.go
+++ b/pkg/exporter/computer.go
@@ -15,8 +15,17 @@ limitations under the License.
 */
 package exporter
 
+import (
+	"github.com/spf13/viper"
+	"strings"
+)
+
 type computerList struct {
 	Computers []computer `json:"computer"`
+}
+
+type label  struct {
+	Name string `json:"name"`
 }
 
 type computer struct {
@@ -25,11 +34,29 @@ type computer struct {
 	Offline bool `json:"offline"`
 	OfflineCauseReason string `json:"offlineCauseReason"`
 	TemporarilyOffline bool `json:"temporarilyOffline"`
+	AssignedLabels []label `json:"assignedLabels"`
+}
+
+func (c *computer) GetCustomTagFromAssignedLabels() string {
+	// If no role is assigned, defaulting to "worker"
+	prefix := viper.GetString("labelrole")
+	role := "worker"
+	for _, label := range c.AssignedLabels {
+		labelName := label.Name
+		if strings.HasPrefix(labelName,prefix) {
+			extractedRole := labelName[len(prefix):]
+			if len(extractedRole) > 0 {
+				role = extractedRole
+			}
+		}
+	}
+	return role
 }
 
 func (c *computer) GetLabelValues() []string  {
 	return []string{
 		c.DisplayName,
+		c.GetCustomTagFromAssignedLabels(),
 	}
 }
 

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -30,6 +30,7 @@ import (
 
 var labelNames = []string {
 	"computerName",
+	"role",
 }
 
 


### PR DESCRIPTION
This is mostly useful if you need to sort out different type of node from your jenkins.